### PR TITLE
Authorization levels

### DIFF
--- a/src/middlewares/accessControl.js
+++ b/src/middlewares/accessControl.js
@@ -1,3 +1,4 @@
+const logger = require('../utils/logger');
 const { User } = require('../models/user');
 
 const isAdmin = async (req, res, next) => {
@@ -12,6 +13,7 @@ const isAdmin = async (req, res, next) => {
       });
     }
   } catch (err) {
+    logger.error(err);
     res.status(500).json(err);
   }
 };
@@ -28,6 +30,7 @@ const isModerator = async (req, res, next) => {
       });
     }
   } catch (err) {
+    logger.error(err);
     res.status(500).json(err);
   }
 };

--- a/src/middlewares/accessControl.js
+++ b/src/middlewares/accessControl.js
@@ -1,0 +1,35 @@
+const { User } = require('../models/user');
+
+const isAdmin = async (req, res, next) => {
+  try {
+    const user = User.findById(req.user.id);
+    if (user.role === 'admin') {
+      next();
+    } else {
+      res.status(400).json({
+        status: 'Fail',
+        message: 'You are trying to access an admin route',
+      });
+    }
+  } catch (err) {
+    res.status(500).json(err);
+  }
+};
+
+const isModerator = async (req, res, next) => {
+  try {
+    const user = User.findById(req.user.id);
+    if (user.role === 'admin' || user.role === 'moderator') {
+      next();
+    } else {
+      res.status(400).json({
+        status: 'Fail',
+        message: 'You are trying to access a moderator route',
+      });
+    }
+  } catch (err) {
+    res.status(500).json(err);
+  }
+};
+
+module.exports = { isAdmin, isModerator };

--- a/src/middlewares/accessControl.js
+++ b/src/middlewares/accessControl.js
@@ -6,7 +6,7 @@ const isAdmin = async (req, res, next) => {
     if (user.role === 'admin') {
       next();
     } else {
-      res.status(400).json({
+      res.status(403).json({
         status: 'Fail',
         message: 'You are trying to access an admin route',
       });
@@ -22,7 +22,7 @@ const isModerator = async (req, res, next) => {
     if (user.role === 'admin' || user.role === 'moderator') {
       next();
     } else {
-      res.status(400).json({
+      res.status(403).json({
         status: 'Fail',
         message: 'You are trying to access a moderator route',
       });

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -56,6 +56,11 @@ const userSchema = new mongoose.Schema(
       type: String,
     },
     googleId: String,
+    role: {
+      type: String,
+      enum: ['user', 'moderator', 'admin'],
+      default: 'user',
+    },
     posts: {
       type: [
         {


### PR DESCRIPTION
Closes #26

## Add authorization levels

- Add role field to `User` model.
- Create `isAdmin` , `isModerator` middlewares.

**Intended to be used in admin/moderator endpoints.**