### PR TITLE
quick-fix postinstall script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 voluntera.log
-/.husky

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn validate-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|json)\"",
     "validate": "yarn format && yarn lint",
     "validate-staged": "lint-staged",
-    "postinstall": "husky install && husky add .husky/pre-commit \"yarn validate-staged\" && husky add .husky/pre-push \"yarn test\""
+    "postinstall": "husky install"
   },
   "dependencies": {
     "bcrypt": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
     "validate-staged": "lint-staged",
     "postinstall": "husky install"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn validate-staged",
+      "pre-push": "yarn test"
+    }
+  },
   "dependencies": {
     "bcrypt": "^5.0.1",
     "dotenv": "^14.2.0",


### PR DESCRIPTION
Fix `postinstall` script to prevent adding multiple `yarn test` `yarn validate` commands to husky hooks.